### PR TITLE
Remove overflow hidden on footer_nav_contain class

### DIFF
--- a/resources/sass/_footer.scss
+++ b/resources/sass/_footer.scss
@@ -231,7 +231,6 @@ footer {
     
     .footer_nav_contain {
         max-height: 0;
-        overflow: hidden;
         transition: max-height .4s ease;
         
         ul {


### PR DESCRIPTION
Before
---
![Screen Shot 2019-08-21 at 1 57 39 PM](https://user-images.githubusercontent.com/1282808/63410153-dbf67000-c41c-11e9-8fe1-c0f2c4932e15.png)

After
---
![Screen Shot 2019-08-21 at 1 57 59 PM](https://user-images.githubusercontent.com/1282808/63410156-de58ca00-c41c-11e9-898c-681a69b426f3.png)